### PR TITLE
Modify name in Strategies

### DIFF
--- a/lib/omniauth/strategies/cognito_idp.rb
+++ b/lib/omniauth/strategies/cognito_idp.rb
@@ -22,7 +22,7 @@ module OmniAuth
   module Strategies
     # OmniAuth strategy that authenticates against an Amazon Cognito User Pool
     class CognitoIdP < OmniAuth::Strategies::OAuth2
-      option :name, 'cognito-idp'
+      option :name, 'cognito_idp'
       option :client_options,
         {
           authorize_url: '/oauth2/authorize',


### PR DESCRIPTION
In order to have rails routing work the name must match
the strategies class name.

https://github.com/Sage/omniauth-cognito-idp/issues/8