### PR TITLE
Rename strategy name to match devise omniauth patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ following ENV variables set:
 * `COGNITO_POOL_SITE`: The domain attached to the user pool.
 
 The application will start at `http://localhost:8678`. You will have to add a callback URL
-`http://localhost:8678/auth/cognito-idp/callback` to the client application in the AWS Console. The test app stores the
+`http://localhost:8678/auth/cognito_idp/callback` to the client application in the AWS Console. The test app stores the
 tokens in memory, so you will need to sign in again after restarting the server.

--- a/config.ru
+++ b/config.ru
@@ -47,7 +47,7 @@ class TestApp < Sinatra::Base
         <pre>#{session[:auth].pretty_inspect}</pre>
         <h2>Links</h2>
         <ul>
-          <li><a href="/auth/cognito-idp">Sign In</a></li>
+          <li><a href="/auth/cognito_idp">Sign In</a></li>
           <li><a href="/userinfo">Userinfo</a></li>
         </ul>
       </body>

--- a/lib/omniauth-cognito-idp/version.rb
+++ b/lib/omniauth-cognito-idp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniAuthCognitoIdP
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 end

--- a/lib/omniauth/strategies/cognito_idp.rb
+++ b/lib/omniauth/strategies/cognito_idp.rb
@@ -22,7 +22,7 @@ module OmniAuth
   module Strategies
     # OmniAuth strategy that authenticates against an Amazon Cognito User Pool
     class CognitoIdP < OmniAuth::Strategies::OAuth2
-      option :name, 'cognito-idp'
+      option :name, 'cognito_idp'
       option :client_options,
         {
           authorize_url: '/oauth2/authorize',


### PR DESCRIPTION
Carbon copy of https://github.com/Sage/omniauth-cognito-idp/pull/12. This should really be fixed.

---

This PR aims to resolve an integration issue between your gem and OmniAuth 2 within the Devise ecosystem. The current problem arises from the strategy name not being properly normalized, resulting in conflicts that skip the middleware. Additionally, there is an issue with the `on_auth_path?` method from the OmniAuth strategy not matching under Devise configurations. Let's delve into these points in more detail for improved clarity and readability.

The specific line in the OmniAuth gem (https://github.com/omniauth/omniauth/blob/a86acdfd7639c9e4c4dc9968d36c1eae0e9141d7/lib/omniauth/strategy.rb#LL187C7-L187C56) expects to find the authentication path that matches the name "cognito-idp".
However, the normalization methods used by Devise expect patterns from Rails routes to use underscores (`_`), resulting in callbacks and methods expecting "cognito_idp".
Consequently, the strategy in the middleware gets ignored because it expects the correct name.
To address this issue, the proposed solution involves renaming the strategy to match the expected methods from Devise's OmniAuth callbacks controller.