### PR TITLE
Use client.site when fetching the access token

### DIFF
--- a/lib/omniauth/strategies/cognito_idp.rb
+++ b/lib/omniauth/strategies/cognito_idp.rb
@@ -67,7 +67,7 @@ module OmniAuth
       def build_access_token
         client.auth_code.get_token(
           request.params['code'],
-          { redirect_uri: callback_url.split('?').first }.merge(token_params.to_hash(symbolize_keys: true)),
+          { redirect_uri: client.site }.merge(token_params.to_hash(symbolize_keys: true)),
           deep_symbolize(options.auth_token_params)
         )
       end

--- a/spec/omniauth/strategies/cognito_idp_spec.rb
+++ b/spec/omniauth/strategies/cognito_idp_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe OmniAuth::Strategies::CognitoIdP do
   let(:options) { {} }
   let(:client_id) { 'ABCDE' }
   let(:client_secret) { '987654321' }
+  let(:site) { "http://localhost/auth/cognito-idp/callback" }
 
   around do |example|
     OmniAuth.config.test_mode = true
@@ -31,10 +32,10 @@ RSpec.describe OmniAuth::Strategies::CognitoIdP do
       end
     end
 
-    let(:oauth_client) { double('OAuth2::Client', auth_code: auth_code) }
+    let(:oauth_client) { double('OAuth2::Client', auth_code: auth_code, site: site) }
     let(:auth_code) { double('OAuth2::AuthCode', get_token: access_token_object) }
     let(:access_token_object) { double('OAuth2::AccessToken') }
-    let(:callback_url) { 'http://localhost/auth/cognito-idp/callback?code=1234' }
+    let(:callback_url) { "#{site}?code=1234" }
 
     let(:request) { double('Rack::Request', params: params) }
     let(:params) { { 'code' => '12345' } }
@@ -57,7 +58,7 @@ RSpec.describe OmniAuth::Strategies::CognitoIdP do
     let(:env) { {} }
     let(:request) { double('Rack::Request', params: {'state' => strategy.session['omniauth.state']}) }
     let(:session) { { 'omniauth.state' => 'some_state' } }
-    let(:oauth_client) { double('OAuth2::Client', auth_code: auth_code) }
+    let(:oauth_client) { double('OAuth2::Client', auth_code: auth_code, site: site) }
     let(:auth_code) { double('OAuth2::AuthCode') }
     let(:access_token_object) { OAuth2::AccessToken.from_hash(oauth_client, token_hash) }
 


### PR DESCRIPTION
This PR solves an issue we had experienced during integration caused by our expected query string parameter set in the `client.site` option being removed resulting in an unauthorized error. 

By using `client.site` instead of `callback_url` we can preserve any query string parameters that may be included within the site key and also configured in the callback url within the user pool client app.